### PR TITLE
fixing variable scope

### DIFF
--- a/ios/ReactNativeSocketMobile.m
+++ b/ios/ReactNativeSocketMobile.m
@@ -6,7 +6,7 @@ RCT_EXPORT_MODULE();
 
 NSString *DecodedData = @"DecodedData";
 NSString *StatusDeviceChanged = @"StatusDeviceChanged";
-bool hasListeners;
+static bool hasListeners;
 
 + (id)allocWithZone:(NSZone *)zone {
     static ReactNativeSocketMobile *sharedInstance = nil;


### PR DESCRIPTION
Solves issue of package not building when other projects have used an unscoped `bool hasListeners`