### PR TITLE
Fix errors with string encoding

### DIFF
--- a/ios/ReactNativeSocketMobile.m
+++ b/ios/ReactNativeSocketMobile.m
@@ -68,7 +68,7 @@ RCT_EXPORT_METHOD(stop: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseReje
 
 -(void)didReceiveDecodedData:(SKTCaptureDecodedData*) decodedData fromDevice:(SKTCaptureHelperDevice*) device withResult:(SKTResult) result{
     if (SKTSUCCESS(result) && socketMobileHasListeners) {
-        [self sendEventWithName:DecodedData body:@{@"data": [NSString stringWithUTF8String:(const char *)[decodedData.DecodedData bytes]]}];
+        [self sendEventWithName:DecodedData body: @{@"data": decodedData.stringFromDecodedData}];
     }
 }
 


### PR DESCRIPTION
### Summary
Reading the barcode '0155-0660; 15586' will crash the app since the data returned is nil and cannot be inserted into a dictionary. Using the decoded string data from the socketmobile sdk returns valid string data

### Test plan
Scan the code 128 barcode encoded by "0155-0660; 15586". Notice that the app will crash. 

![test-barcode](https://user-images.githubusercontent.com/4528172/61892143-cac74b80-aed0-11e9-8943-a2fee6f20f3b.jpg)
